### PR TITLE
feat: Add database persistence for processed receipts

### DIFF
--- a/.env.copy
+++ b/.env.copy
@@ -7,3 +7,14 @@ TELEGRAM_BOT_SECRET_TOKEN="<BOT_SECRET_TOKEN>"
 
 # Controls whether to automatically create an ngrok tunnel for local dev
 USE_NGROK=False
+
+# Database connection URL. Support SQLite, PostgreSQL, etc.
+# Examples:
+#   SQLite: sqlite:///./receipts.db
+#   PostgreSQL: postgresql://user:password@localhost:5432/receipts
+DATABASE_URL="<DATABASE_URL>"
+
+# Optional database connection parameters as JSON
+# SQLite example: DATABASE_OPTIONS={"check_same_thread": false}
+# PostgreSQL example: DATABASE_OPTIONS={"pool_size": 10, "max_overflow": 20}
+DATABASE_OPTIONS={}

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/osx,python
+
+# local database
+*.db

--- a/app/cli.py
+++ b/app/cli.py
@@ -24,6 +24,7 @@ from app.agent import (
     ReceiptProcessingError,
     run_receipt_agent,
 )
+from app.operations import save_receipt_into_db
 
 
 def main():
@@ -63,6 +64,7 @@ def main():
     try:
         receipt_output = asyncio.run(run_receipt_agent(receipt_path=receipt_filepath))
         if isinstance(receipt_output, ReceiptInfo):
+            save_receipt_into_db(receipt_output)
             logging.info("Receipt processed successfully:")
             logging.info(receipt_output.model_dump_json(indent=2))
         else:

--- a/app/cli.py
+++ b/app/cli.py
@@ -64,7 +64,7 @@ def main():
     try:
         receipt_output = asyncio.run(run_receipt_agent(receipt_path=receipt_filepath))
         if isinstance(receipt_output, ReceiptInfo):
-            save_receipt_into_db(receipt_output)
+            asyncio.run(save_receipt_into_db(receipt_output))
             logging.info("Receipt processed successfully:")
             logging.info(receipt_output.model_dump_json(indent=2))
         else:
@@ -77,4 +77,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,49 @@
+from functools import lru_cache
+from typing import Any, Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppSettings(BaseSettings):
+    """
+    Application settings for the Telegram webhook.
+
+    Attributes:
+        use_ngrok (bool): Whether to use ngrok for local development. Defaults to False.
+        on_render (bool): Indicates if the application is running on Render.com.
+            Defaults to False, aliased from "render" environment variable.
+        render_external_url (Optional[str]): The external URL provided by Render.com
+            when deployed. Required if `on_render` is True.
+        telegram_bot_token (str): The secret token for the Telegram bot API.
+        telegram_bot_secret_token (Optional[str]): An optional secret token for
+            webhook validation, used to secure the webhook.
+        disable_logfire (bool): Whether to disable Logfire instrumentation. Defaults to False.
+        database_url (str): The URL for the database connection.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="allow"
+    )
+
+    use_ngrok: bool = False
+    on_render: bool = Field(alias="render", default=False)
+    render_external_url: Optional[str] = None
+    telegram_bot_token: str
+    telegram_bot_secret_token: Optional[str] = None
+    disable_logfire: bool = False
+    database_url: str
+    database_options: Optional[dict[str, Any]] = None
+
+
+@lru_cache
+def get_app_settings() -> AppSettings:
+    """Retrieves the application settings.
+
+    This function is cached to ensure that `AppSettings` are loaded only once
+    from environment variables.
+
+    Returns:
+        AppSettings: An instance of the application settings.
+    """
+    return AppSettings()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,44 @@
+from contextlib import contextmanager
+from typing import Generator
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.config import get_app_settings
+
+
+app_settings = get_app_settings()
+
+
+engine = create_engine(
+    app_settings.database_url, connect_args=app_settings.database_options
+)
+
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_db_session() -> Generator[Session, None, None]:
+    """Provides a database session.
+
+    This generator function yields a SQLModel Session instance, ensuring
+    it is properly closed after use when used with `contextlib.contextmanager`.
+
+    Yields:
+        sqlmodel.Session: A database session instance.
+    """
+    with Session(engine) as session:
+        yield session
+
+
+db_session = contextmanager(get_db_session)
+"""
+Provides a database session as a context manager.
+
+This context manager can be used to obtain a `SQLModel.Session` instance,
+ensuring that the session is properly closed after use.
+
+Usage:
+    with db_session() as session:
+        # Perform database operations with 'session'
+        ...
+"""

--- a/app/main.py
+++ b/app/main.py
@@ -18,8 +18,6 @@ from dotenv import load_dotenv
 
 load_dotenv()  # Load environment variables from .env file. This is needed for variables like GITHUB_API_KEY, which are not managed by AppSettings.
 from fastapi import BackgroundTasks, Depends, FastAPI, Header, HTTPException, Request
-from pydantic import Field
-from pydantic_settings import BaseSettings
 
 from app.agent import (
     InvalidReceipt,
@@ -27,47 +25,13 @@ from app.agent import (
     ReceiptInfo,
     ReceiptProcessingError,
 )
+from app.config import AppSettings, get_app_settings
+from app.db import create_db_and_tables
+from app.operations import save_receipt_into_db
 
 
 # Configure logging
 logger = logging.getLogger(__name__)
-
-
-class AppSettings(BaseSettings):
-    """
-    Application settings for the Telegram webhook.
-
-    Attributes:
-        use_ngrok (bool): Whether to use ngrok for local development. Defaults to False.
-        on_render (bool): Indicates if the application is running on Render.com.
-            Defaults to False, aliased from "render" environment variable.
-        render_external_url (Optional[str]): The external URL provided by Render.com
-            when deployed. Required if `on_render` is True.
-        telegram_bot_token (str): The secret token for the Telegram bot API.
-        telegram_bot_secret_token (Optional[str]): An optional secret token for
-            webhook validation, used to secure the webhook.
-        disable_logfire (bool): Whether to disable Logfire instrumentation. Defaults to False.
-    """
-
-    use_ngrok: bool = False
-    on_render: bool = Field(alias="render", default=False)
-    render_external_url: Optional[str] = None
-    telegram_bot_token: str
-    telegram_bot_secret_token: Optional[str] = None
-    disable_logfire: bool = False
-
-
-@lru_cache
-def get_app_settings() -> AppSettings:
-    """Retrieves the application settings.
-
-    This function is cached to ensure that `AppSettings` are loaded only once
-    from environment variables.
-
-    Returns:
-        AppSettings: An instance of the application settings.
-    """
-    return AppSettings()
 
 
 class TelegramBotAPIError(Exception):
@@ -181,7 +145,7 @@ class TelegramBotClient:
     ) -> None:
         """
         Set the webhook URL for the bot.
-        
+
         This is equivalent to the curl command:
         curl -F "url=https://<ngrok_url>/webhook" \
           https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook
@@ -355,7 +319,6 @@ async def lifespan(app: FastAPI):
     # Workaround: Allows `get_app_settings` dependency to be overridden for testing,
     # as `Depends` is not available in lifespan.
     settings = app.dependency_overrides.get(get_app_settings, get_app_settings)()
-
     # setup instrumentation with logfire
     if not settings.disable_logfire:
         logfire.configure(
@@ -363,6 +326,10 @@ async def lifespan(app: FastAPI):
         )
         logfire.instrument_fastapi(app)
         logfire.instrument_pydantic_ai()
+
+    # create database tables on startup
+    # TODO: For production, consider using a dedicated database migration script.
+    create_db_and_tables()
 
     telegram_client = get_telegram_bot_client(settings.telegram_bot_token)
     public_url, needs_ngrok_cleanup = _get_public_url(settings)
@@ -397,7 +364,7 @@ def _format_html_receipt_data_for_telegram(receipt_data: ReceiptInfo) -> str:
     """
     payment_method_display = receipt_data.payment_method.replace("_", " ").title()
     _html = f"""
-    🧾 <b>Receipt Details:</b>    
+    🧾 <b>Receipt Details:</b>
     📅 <b>Issued At:</b> {receipt_data.issued_at.strftime("%B %d, %Y at %I:%M %p")}
     🏢 <b>Vendor Name:</b> {receipt_data.vendor_name}
     🆔 <b>Vendor RUC:</b> {receipt_data.vendor_ruc}
@@ -441,6 +408,7 @@ async def handle_incoming_message(
         try:
             receipt_output = await run_receipt_agent(photo_url, text)
             if isinstance(receipt_output, ReceiptInfo):
+                save_receipt_into_db(receipt_output)
                 text = _format_html_receipt_data_for_telegram(receipt_output)
                 parse_mode = "HTML"
             elif isinstance(receipt_output, InvalidReceipt):
@@ -532,4 +500,3 @@ async def webhook(
 async def health_check():
     """Health check endpoint to verify service is running."""
     return {"status": "healthy"}
-

--- a/app/main.py
+++ b/app/main.py
@@ -329,7 +329,7 @@ async def lifespan(app: FastAPI):
 
     # create database tables on startup
     # TODO: For production, consider using a dedicated database migration script.
-    create_db_and_tables()
+    await create_db_and_tables()
 
     telegram_client = get_telegram_bot_client(settings.telegram_bot_token)
     public_url, needs_ngrok_cleanup = _get_public_url(settings)
@@ -408,7 +408,7 @@ async def handle_incoming_message(
         try:
             receipt_output = await run_receipt_agent(photo_url, text)
             if isinstance(receipt_output, ReceiptInfo):
-                save_receipt_into_db(receipt_output)
+                await save_receipt_into_db(receipt_output)
                 text = _format_html_receipt_data_for_telegram(receipt_output)
                 parse_mode = "HTML"
             elif isinstance(receipt_output, InvalidReceipt):

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal, Optional
+
+from sqlmodel import Field, SQLModel, String
+
+
+class Receipt(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    issued_at: datetime = Field(description="Date and time when the receipt was issued")
+    vendor_name: Optional[str] = Field(description="Receipt Vendor Name")
+    vendor_ruc: Optional[str] = Field(
+        description="Receipt Vendor RUC. Ignore for Yape and Plin"
+    )
+    currency: str = Field(
+        description="Currency code of the receipt (e.g., 'PEN' for Peruvian Sol, 'USD' for US Dollar). Use ISO 4217 standard currency codes when possible."
+    )
+    total_amount: Decimal = Field(
+        max_digits=10, decimal_places=2, description="Total Amount"
+    )
+    tip: Decimal = Field(
+        max_digits=5,
+        decimal_places=2,
+        description="The tip amount. Set to 0 if not present.",
+    )
+    payment_method: Literal["credit_card", "debit_card", "transfer", "yape", "plin"] = (
+        Field(
+            sa_type=String,
+            description="Payment method used. Classify IZIPAY as 'credit_card'.",
+        )
+    )
+    note: str = Field(
+        description="What the receipt is about. This information is usually provided in the user query. For Yape and Plin receipt, a small description might be present in the receipt itself, but the user query is predominant if provided."
+    )

--- a/app/operations.py
+++ b/app/operations.py
@@ -1,9 +1,9 @@
 from app.agent import ReceiptInfo
-from app.db import db_session
+from app.db import async_db_session
 from app.models import Receipt
 
 
-def save_receipt_into_db(receipt: ReceiptInfo) -> Receipt:
+async def save_receipt_into_db(receipt: ReceiptInfo) -> Receipt:
     """Saves extracted receipt information into the database.
 
     This function takes a `ReceiptInfo` object, maps its fields to the `Receipt`
@@ -17,7 +17,7 @@ def save_receipt_into_db(receipt: ReceiptInfo) -> Receipt:
         Receipt: The `Receipt` object as it was saved in the database,
             including any database-generated fields.
     """
-    with db_session() as session:
+    async with async_db_session() as session:
         receipt_at_db = Receipt(
             issued_at=receipt.issued_at,
             vendor_name=receipt.vendor_name,
@@ -29,6 +29,6 @@ def save_receipt_into_db(receipt: ReceiptInfo) -> Receipt:
             note=receipt.note,
         )
         session.add(receipt_at_db)
-        session.commit()
-        session.refresh(receipt_at_db)
+        await session.commit()
+        await session.refresh(receipt_at_db)
         return receipt_at_db

--- a/app/operations.py
+++ b/app/operations.py
@@ -1,0 +1,34 @@
+from app.agent import ReceiptInfo
+from app.db import db_session
+from app.models import Receipt
+
+
+def save_receipt_into_db(receipt: ReceiptInfo) -> Receipt:
+    """Saves extracted receipt information into the database.
+
+    This function takes a `ReceiptInfo` object, maps its fields to the `Receipt`
+    SQLModel, and persists it to the database.
+
+    Args:
+        receipt (ReceiptInfo): An instance of `ReceiptInfo` containing the
+            structured data extracted from a receipt.
+
+    Returns:
+        Receipt: The `Receipt` object as it was saved in the database,
+            including any database-generated fields.
+    """
+    with db_session() as session:
+        receipt_at_db = Receipt(
+            issued_at=receipt.issued_at,
+            vendor_name=receipt.vendor_name,
+            vendor_ruc=receipt.vendor_ruc,
+            currency=receipt.currency,
+            total_amount=receipt.total_amount,
+            tip=receipt.tip,
+            payment_method=receipt.payment_method,
+            note=receipt.note,
+        )
+        session.add(receipt_at_db)
+        session.commit()
+        session.refresh(receipt_at_db)
+        return receipt_at_db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.116.1",
+    "greenlet>=3.2.4",
     "logfire[fastapi]>=4.3.6",
     "pydantic-ai[logfire]>=0.8.0",
     "pydantic-settings>=2.10.1",
@@ -20,6 +21,7 @@ receipt-agent = "app.cli:main"
 
 [dependency-groups]
 dev = [
+    "aiosqlite>=0.21.0",
     "pyngrok>=7.3.0",
     "pytest>=8.4.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic-ai[logfire]>=0.8.0",
     "pydantic-settings>=2.10.1",
     "python-dotenv>=1.1.1",
+    "sqlmodel>=0.0.25",
 ]
 
 [project.scripts]

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import AppSettings, app, get_app_settings
+from app.main import app
+from app.config import AppSettings, get_app_settings
 
 
 def _app_settings_factory(**kwargs) -> Callable[[], AppSettings]:

--- a/uv.lock
+++ b/uv.lock
@@ -557,6 +557,39 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
+    { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
+    { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
+]
+
+[[package]]
 name = "griffe"
 version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1633,6 +1666,7 @@ dependencies = [
     { name = "pydantic-ai", extra = ["logfire"] },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "sqlmodel" },
 ]
 
 [package.dev-dependencies]
@@ -1648,6 +1682,7 @@ requires-dist = [
     { name = "pydantic-ai", extras = ["logfire"], specifier = ">=0.8.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "sqlmodel", specifier = ">=0.0.25" },
 ]
 
 [package.metadata.requires-dev]
@@ -1901,6 +1936,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/bc/d59b5d97d27229b0e009bd9098cd81af71c2fa5549c580a0a67b9bed0496/sqlalchemy-2.0.43.tar.gz", hash = "sha256:788bfcef6787a7764169cfe9859fe425bf44559619e1d9f56f5bddf2ebf6f417", size = 9762949, upload-time = "2025-08-11T14:24:58.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/db/20c78f1081446095450bdc6ee6cc10045fce67a8e003a5876b6eaafc5cc4/sqlalchemy-2.0.43-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:20d81fc2736509d7a2bd33292e489b056cbae543661bb7de7ce9f1c0cd6e7f24", size = 2134891, upload-time = "2025-08-11T15:51:13.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0a/3d89034ae62b200b4396f0f95319f7d86e9945ee64d2343dcad857150fa2/sqlalchemy-2.0.43-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:25b9fc27650ff5a2c9d490c13c14906b918b0de1f8fcbb4c992712d8caf40e83", size = 2123061, upload-time = "2025-08-11T15:51:14.319Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/10/2711f7ff1805919221ad5bee205971254845c069ee2e7036847103ca1e4c/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6772e3ca8a43a65a37c88e2f3e2adfd511b0b1da37ef11ed78dea16aeae85bd9", size = 3320384, upload-time = "2025-08-11T15:52:35.088Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0e/3d155e264d2ed2778484006ef04647bc63f55b3e2d12e6a4f787747b5900/sqlalchemy-2.0.43-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a113da919c25f7f641ffbd07fbc9077abd4b3b75097c888ab818f962707eb48", size = 3329648, upload-time = "2025-08-11T15:56:34.153Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/81/635100fb19725c931622c673900da5efb1595c96ff5b441e07e3dd61f2be/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4286a1139f14b7d70141c67a8ae1582fc2b69105f1b09d9573494eb4bb4b2687", size = 3258030, upload-time = "2025-08-11T15:52:36.933Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/a99302716d62b4965fded12520c1cbb189f99b17a6d8cf77611d21442e47/sqlalchemy-2.0.43-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:529064085be2f4d8a6e5fab12d36ad44f1909a18848fcfbdb59cc6d4bbe48efe", size = 3294469, upload-time = "2025-08-11T15:56:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a2/3a11b06715149bf3310b55a98b5c1e84a42cfb949a7b800bc75cb4e33abc/sqlalchemy-2.0.43-cp312-cp312-win32.whl", hash = "sha256:b535d35dea8bbb8195e7e2b40059e2253acb2b7579b73c1b432a35363694641d", size = 2098906, upload-time = "2025-08-11T15:55:00.645Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/09/405c915a974814b90aa591280623adc6ad6b322f61fd5cff80aeaef216c9/sqlalchemy-2.0.43-cp312-cp312-win_amd64.whl", hash = "sha256:1c6d85327ca688dbae7e2b06d7d84cfe4f3fffa5b5f9e21bb6ce9d0e1a0e0e0a", size = 2126260, upload-time = "2025-08-11T15:55:02.965Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1c/a7260bd47a6fae7e03768bf66451437b36451143f36b285522b865987ced/sqlalchemy-2.0.43-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e7c08f57f75a2bb62d7ee80a89686a5e5669f199235c6d1dac75cd59374091c3", size = 2130598, upload-time = "2025-08-11T15:51:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/84/8a337454e82388283830b3586ad7847aa9c76fdd4f1df09cdd1f94591873/sqlalchemy-2.0.43-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14111d22c29efad445cd5021a70a8b42f7d9152d8ba7f73304c4d82460946aaa", size = 2118415, upload-time = "2025-08-11T15:51:17.256Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ff/22ab2328148492c4d71899d62a0e65370ea66c877aea017a244a35733685/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21b27b56eb2f82653168cefe6cb8e970cdaf4f3a6cb2c5e3c3c1cf3158968ff9", size = 3248707, upload-time = "2025-08-11T15:52:38.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/29/11ae2c2b981de60187f7cbc84277d9d21f101093d1b2e945c63774477aba/sqlalchemy-2.0.43-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c5a9da957c56e43d72126a3f5845603da00e0293720b03bde0aacffcf2dc04f", size = 3253602, upload-time = "2025-08-11T15:56:37.348Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/61/987b6c23b12c56d2be451bc70900f67dd7d989d52b1ee64f239cf19aec69/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d79f9fdc9584ec83d1b3c75e9f4595c49017f5594fee1a2217117647225d738", size = 3183248, upload-time = "2025-08-11T15:52:39.865Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/29d216002d4593c2ce1c0ec2cec46dda77bfbcd221e24caa6e85eff53d89/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9df7126fd9db49e3a5a3999442cc67e9ee8971f3cb9644250107d7296cb2a164", size = 3219363, upload-time = "2025-08-11T15:56:39.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e4/bd78b01919c524f190b4905d47e7630bf4130b9f48fd971ae1c6225b6f6a/sqlalchemy-2.0.43-cp313-cp313-win32.whl", hash = "sha256:7f1ac7828857fcedb0361b48b9ac4821469f7694089d15550bbcf9ab22564a1d", size = 2096718, upload-time = "2025-08-11T15:55:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a5/ca2f07a2a201f9497de1928f787926613db6307992fe5cda97624eb07c2f/sqlalchemy-2.0.43-cp313-cp313-win_amd64.whl", hash = "sha256:971ba928fcde01869361f504fcff3b7143b47d30de188b11c6357c0505824197", size = 2123200, upload-time = "2025-08-11T15:55:07.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/13bdde6521f322861fab67473cec4b1cc8999f3871953531cf61945fad92/sqlalchemy-2.0.43-py3-none-any.whl", hash = "sha256:1681c21dd2ccee222c2fe0bef671d1aef7c504087c9c4e800371cfcc8ac966fc", size = 1924759, upload-time = "2025-08-11T15:39:53.024Z" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/d9c098a88724ee4554907939cf39590cf67e10c6683723216e228d3315f7/sqlmodel-0.0.25.tar.gz", hash = "sha256:56548c2e645975b1ed94d6c53f0d13c85593f57926a575e2bf566650b2243fa4", size = 117075, upload-time = "2025-09-17T21:44:41.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/cf/5d175ce8de07fe694ec4e3d4d65c2dd06cc30f6c79599b31f9d2f6dd2830/sqlmodel-0.0.25-py3-none-any.whl", hash = "sha256:c98234cda701fb77e9dcbd81688c23bb251c13bb98ce1dd8d4adc467374d45b7", size = 28893, upload-time = "2025-09-17T21:44:39.764Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -88,6 +88,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1662,6 +1674,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "greenlet" },
     { name = "logfire", extra = ["fastapi"] },
     { name = "pydantic-ai", extra = ["logfire"] },
     { name = "pydantic-settings" },
@@ -1671,6 +1684,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "pyngrok" },
     { name = "pytest" },
 ]
@@ -1678,6 +1692,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
+    { name = "greenlet", specifier = ">=3.2.4" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=4.3.6" },
     { name = "pydantic-ai", extras = ["logfire"], specifier = ">=0.8.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
@@ -1687,6 +1702,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "pyngrok", specifier = ">=7.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
 ]


### PR DESCRIPTION
## Description
This PR introduces database persistence to save processed receipts for future reference. Previously, receipts were only processed and displayed without being stored.

## What's Changed
- Added SQLModel-based database layer for receipt persistence
- Refactored application settings into a dedicated config module (add `DATABASE_URL` and `DATABASE_OPTIONS`)
- Receipts are now automatically saved to the database after successful processing
- Updated both CLI and webhook handlers to persist receipts

## TODO (Before Merge)
- [x] Add async database support
- [ ] Implement proper database migrations with Alembic
- [ ] Add Tests